### PR TITLE
Fix order page link

### DIFF
--- a/zamowienie.html
+++ b/zamowienie.html
@@ -118,7 +118,7 @@
     <p>Tytuł: *twoje imię i nazwisko* - opłata za buty</p>
     <p>Odbiorca: STONELOVE Anna Karelus</p>
     <p>Numer konta: 56 1020 1433 0000 1202 0210 3547</p>
-    <a href="karelus_shop_mvp.html" class="button">Wróć do katalogu</a>
+    <a href="index.html" class="button">Wróć do katalogu</a>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix catalog link on the order page so "Wróć do katalogu" returns to index.html

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685863236a4c8321b3493d0c6e7db685