### PR TITLE
Add thank-you page

### DIFF
--- a/thank-you.html
+++ b/thank-you.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dziękujemy za zamówienie</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 2rem;
+      background: #fdfaf5;
+    }
+    .button {
+      background-color: #5a3e2b;
+      color: white;
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 0.25rem;
+      margin-top: 1rem;
+      cursor: pointer;
+    }
+    .button:hover {
+      background-color: #472e20;
+    }
+  </style>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const params = new URLSearchParams(window.location.search);
+      const orderId = params.get('orderId') || localStorage.getItem('orderId');
+      if (orderId) {
+        document.getElementById('order-id').textContent = orderId;
+      }
+    });
+  </script>
+</head>
+<body>
+  <h1>Dziękujemy za zamówienie!</h1>
+  <p>Twoje zamówienie zostało przyjęte.</p>
+  <p>Numer zamówienia: <strong id="order-id"></strong></p>
+  <p><strong>Dane do przelewu:</strong></p>
+  <p>Tytuł: *twoje imię i nazwisko* - opłata za buty</p>
+  <p>Odbiorca: STONELOVE Anna Karelus</p>
+  <p>Numer konta: 56 1020 1433 0000 1202 0210 3547</p>
+  <a class="button" href="index.html">Wróć do katalogu</a>
+</body>
+</html>

--- a/zamowienie.html
+++ b/zamowienie.html
@@ -25,8 +25,8 @@
       if (form) {
         form.addEventListener("submit", function (e) {
           e.preventDefault();
-          document.getElementById("confirmation").classList.remove("hidden");
-          form.classList.add("hidden");
+          const orderId = Date.now().toString();
+          window.location.href = "thank-you.html?orderId=" + encodeURIComponent(orderId);
         });
       }
     });
@@ -111,14 +111,5 @@
     <button class="button" type="submit">Wyślij zamówienie</button>
   </form>
 
-  <div id="confirmation" class="hidden">
-    <h2>Dziękujemy za zamówienie!</h2>
-    <p>Twoje zamówienie zostało przyjęte.</p>
-    <p><strong>Dane do przelewu:</strong></p>
-    <p>Tytuł: *twoje imię i nazwisko* - opłata za buty</p>
-    <p>Odbiorca: STONELOVE Anna Karelus</p>
-    <p>Numer konta: 56 1020 1433 0000 1202 0210 3547</p>
-    <a href="karelus_shop_mvp.html" class="button">Wróć do katalogu</a>
-  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `thank-you.html` confirmation page
- generate order ID and redirect to confirmation page from `zamowienie.html`
- remove inline confirmation block

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858638a6b6c8321a055b0ee44fde1a3