### PR TITLE
Add accessory tooltips

### DIFF
--- a/zamowienie.html
+++ b/zamowienie.html
@@ -56,6 +56,12 @@
     .button:hover {
       background-color: #472e20;
     }
+    .info-icon {
+      cursor: help;
+      margin-left: 0.25rem;
+      font-weight: bold;
+      color: #5a3e2b;
+    }
   </style>
 </head>
 <body>
@@ -99,10 +105,10 @@
 
     <fieldset>
       <legend>Akcesoria:</legend>
-      <label><input type="checkbox"> Dedykowany wosk do butów - 60 zł</label>
-      <label><input type="checkbox"> Wkładki antybakteryjne - 100 zł</label>
-      <label><input type="checkbox"> Srebro do dezynfekcji - 80 zł</label>
-      <label><input type="checkbox"> Prawidła sosnowe - 150 zł</label>
+      <label><input type="checkbox"> Dedykowany wosk do butów - 60 zł <span class="info-icon" title="Chroni skórę i impregnuje">?</span></label>
+      <label><input type="checkbox"> Wkładki antybakteryjne - 100 zł <span class="info-icon" title="Zapobiegają powstawaniu przykrych zapachów">?</span></label>
+      <label><input type="checkbox"> Srebro do dezynfekcji - 80 zł <span class="info-icon" title="Koloidalny roztwór do spryskiwania wnętrza butów">?</span></label>
+      <label><input type="checkbox"> Prawidła sosnowe - 150 zł <span class="info-icon" title="Prawidła: pomagają utrzymać kształt buta i wchłaniają wilgoć">?</span></label>
     </fieldset>
 
     <label>Hasło rabatowe:<br><input type="text"></label>


### PR DESCRIPTION
## Summary
- show info icons next to accessories on order form
- style info icons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858638b227083218f24161f61ff066b