### PR TITLE
Fix return link on order page

### DIFF
--- a/zamowienie.html
+++ b/zamowienie.html
@@ -157,7 +157,7 @@
     <p id="bank-title">Tytuł: *twoje imię i nazwisko* - opłata za buty</p>
     <p>Odbiorca: STONELOVE Anna Karelus</p>
     <p>Numer konta: 56 1020 1433 0000 1202 0210 3547</p>
-    <a href="karelus_shop_mvp.html" class="button">Wróć do katalogu</a>
+    <a href="index.html" class="button">Wróć do katalogu</a>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix the catalog return link on the order page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685863dc79b883218c1c12eeddb67ab2