### PR TITLE
Add dedicated confirmation page

### DIFF
--- a/thank-you.html
+++ b/thank-you.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dziękujemy za zamówienie</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 2rem;
+      background: #fdfaf5;
+    }
+    .button {
+      background-color: #5a3e2b;
+      color: white;
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 0.25rem;
+      margin-top: 1rem;
+      display: inline-block;
+      text-decoration: none;
+    }
+    .button:hover {
+      background-color: #472e20;
+    }
+  </style>
+</head>
+<body>
+  <h1>Dziękujemy za zamówienie!</h1>
+  <p>Twoje zamówienie zostało przyjęte.</p>
+  <p>ID zamówienia: <span id="order-id"></span></p>
+  <p><strong>Dane do przelewu:</strong></p>
+  <p id="bank-title"></p>
+  <p>Odbiorca: STONELOVE Anna Karelus</p>
+  <p>Numer konta: 56 1020 1433 0000 1202 0210 3547</p>
+  <a href="index.html" class="button">Wróć do katalogu</a>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const orderId = params.get('orderId');
+    const name = params.get('name') || '';
+    if (orderId) {
+      document.getElementById('order-id').textContent = orderId;
+      document.getElementById('bank-title').textContent = `Tytuł: ${name} - opłata za buty ${orderId}`;
+    }
+  </script>
+</body>
+</html>

--- a/zamowienie.html
+++ b/zamowienie.html
@@ -59,11 +59,10 @@
           e.preventDefault();
           const nameInput = document.getElementById("customer-name");
           const initials = nameInput.value.trim().split(/\s+/).map(w => w.charAt(0).toUpperCase()).join('');
+          const name = nameInput.value.trim();
           const orderId = Date.now() + initials;
-          document.getElementById("order-id").textContent = orderId;
-          document.getElementById("bank-title").textContent = `Tytuł: ${nameInput.value.trim()} - opłata za buty ${orderId}`;
-          document.getElementById("confirmation").classList.remove("hidden");
-          form.classList.add("hidden");
+          const params = new URLSearchParams({ orderId, name });
+          window.location.href = `thank-you.html?${params.toString()}`;
         });
       }
     });


### PR DESCRIPTION
## Summary
- create `thank-you.html` page to show order id and payment details
- redirect form submission to the new page with the generated id

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685874b2d6248321afaf6ed1f6f88fdf